### PR TITLE
add option to merge matching metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9-alpine AS build-env
+FROM golang:1.12.7-alpine AS build-env
 
 RUN apk add --no-cache git make
 

--- a/cmd/handler_test.go
+++ b/cmd/handler_test.go
@@ -89,7 +89,7 @@ func TestHandler(t *testing.T) {
 	barWanted := 4.0
 	var bar float64
 
-	var conflictWanted sort.Float64Slice = []float64{2.0, 5.0}
+	var conflictWanted sort.Float64Slice = []float64{7.0}
 	var conflict sort.Float64Slice = make([]float64, 0)
 
 	sharedWanted := map[string]float64{"a": 3.0, "b": 6.0}

--- a/golang.mk
+++ b/golang.mk
@@ -67,7 +67,7 @@ xc:
 	GOOS=linux GOARCH=amd64 make build
 	GOOS=darwin GOARCH=amd64 make build
 
-install: test
+install: vendor test
 	go install \
 		$(BUILD_FLAGS)
 


### PR DESCRIPTION
Extend the original idea of merging metrics from multiple sources to a
single endpoint by merging matching metrics. This allows the exporter
to be used against scaled container in simple environments without
exposing multiple ports to Prometheus.

The functionality is contained, but no flag to disable it is provided.

Signed-off-by: Martin Polednik <m.polednik@gmail.com>